### PR TITLE
Implementing confidence intervals for ACPL

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -8,7 +8,6 @@ from functools import partial
 import math
 from math import *
 from random import *
-import time
 
 # TODO: Make this configurable via the config file.
 _cp_loss_intervals = [0, 10, 25, 50, 100, 200, 500]
@@ -26,19 +25,21 @@ def generate_stats_string_csv(sample, total):
     stderr = std_error(percentage, total)
     #Was there any reason to not use a Wilson interval on CSV export?
     ci = wilson_interval(sample, total)
-    return f'{sample}/{total},{percentage:.01%},{ci[0]*100:.01f},{ci[1]*100:.01f}'
+    return f'{sample}/{total},{percentage:.01%},{ci[0]*100:.01f} - {ci[1]*100:.01f}'
 
 def std_error(p, n):
     return math.sqrt(p*(1-p)/n)
 
 # based on normal distribution, better to use wilson_interval defined below.
+# these are used for T% and >CPL metrics.
 def confidence_interval(p, e):
     return [
         p - (2.0*e),
         p + (2.0*e)
     ]
 
-#Courtesy of bufferunderrun. Speedier random number generation
+# courtesy of bufferunderrun, speedier random number generation.
+# used for BCa intervals. i think the only way to get this faster is using numpy.
 def randrange_stripped(n):
     k = n.bit_length()  # don't use (n-1) here because n can be 1
     r = getrandbits(k)  # 0 <= r < 2**k
@@ -46,35 +47,8 @@ def randrange_stripped(n):
         r = getrandbits(k)
     return r
 
-#Empirical bootstrap interval - takes sample array and returns 95% CI
-#BCa is a work in progress
-def bootstrap_interval(array): #assumes 95% intervals as a convention
-    mn = 0
-    temparray = []
-    for X in array:
-        temparray += X
-    mn = 1.0*sum(temparray)/len(temparray)
-
-    deltas = []
-    for X in range(0,20000): #1000 bootstrap samples seems like a nice number
-        #Games are sampled, not moves. ACPL calculated on move-basis, though.
-        #Games in bootstrap sample is equal to number of games in CR sample.
-        #This means not every bootstrap sample has the same number of moves.
-        bootsample = []
-        for Y in range(0,len(array)):
-            randnum = randrange_stripped(len(array))
-            bootsample += array[randnum]
-        #print(bootsample)
-        deltas.append((sum(bootsample) / len(bootsample)) - mn)
-    deltas = sorted(deltas)
-    d975 = math.floor(0.025 * len(deltas))
-    d025 = len(deltas) - d975
-    lowerval = deltas[d975] #should correspond to the 2.5th percentile
-    upperval = deltas[d025] #should correspond to the 97.5th percentile
-
-    #Source: https://ocw.mit.edu/courses/mathematics/18-05-introduction-to-probability-and-statistics-spring-2014/readings/MIT18_05S14_Reading24.pdf
-    return [round(mn - upperval,1), round(mn - lowerval,1)]
-
+# used for BCa intervals. cumulative bootstrap distribution function.
+# returns percentile of a given value.
 def Gcdf(sortedarray, value):
     X = 0.0
     for X in range(0,len(sortedarray)):
@@ -82,6 +56,8 @@ def Gcdf(sortedarray, value):
             break
     return X / len(sortedarray)
 
+# used for BCa intervals. inverse cumulative bootstrap distribution function.
+# returns the value associatd with a given percentile.
 def invGcdf(sortedarray, value):
     index = math.floor(value*len(sortedarray))
     #print(index)
@@ -91,13 +67,14 @@ def invGcdf(sortedarray, value):
         return sortedarray[0]
     return sortedarray[math.floor(value*len(sortedarray))]
 
+# used for BCa instervals. estimates acceleration parameter.
+# acceleration parameter is proportional to skewness.
 def skewness(sarray,larray): #jackknife method
     mean = sum(sarray)/sum(larray)
     h = sum(sarray)
     i = sum(larray)
     M3 = 0.0
     M2 = 0.0
-    st = time.time()
     if len(larray) < 2:
         return 0
     for X in range(0,len(larray)):
@@ -105,16 +82,17 @@ def skewness(sarray,larray): #jackknife method
         M3 += (mean-jkmean)**3
         M2 += (mean-jkmean)**2
 
-    #print("Jackknife time: " +  str(time.time()-st))
     if M2 != 0:
         return M3 / (6 * (M2 ** 1.5))
     return 0
 
+# normal cumulative distribution function. uses erfc to avoid imports.
 def cdf(x):
     return 0.5 * math.erfc(-x/sqrt(2))
 
+# inverse cumulative distribution function. avoiding imports.
 def invcdf(phi): #bisection method
-    tolerance = 0.000001 #how far off we're willing to be
+    tolerance = 0.000001 #how far off we're willing to be on final answer
     lowerbound = -99.0
     upperbound = 99.0
     xguess = 0.5
@@ -130,17 +108,22 @@ def invcdf(phi): #bisection method
 
     return xguess
 
+# bias corrected and accelerated interval. used for ACPL.
+# https://www.tau.ac.il/~saharon/Boot/10.1.1.133.8405.pdf for theory
 def bca(array):
-    bssize = 20000 #20000 samples reproducibly gives upper and lower CIs +/-0.2
-    deltas = [0]*bssize
-    #stime = time.time()
-    sarray = [0]*len(array)
-    larray = [0]*len(array)
+    if len(array) < 2:
+        return ['-', '-']
+    bssize = 20000-1 #19999 samples reproducibly gives upper and lower CIs +/-0.2
+    deltas = [0]*bssize #bootstrap samples. deltas was the legacy name used for a reverse percentile method (not being used)
+    sarray = [0]*len(array) #sum of CPLs in individual games
+    larray = [0]*len(array) #number of moves in individual games
+
+    #calculating ACPLs like this cuts down computation time.
+    #averages are calculated with weighted sums instead of temporary arrays
     for X in range(0,len(array)):
-        #print(array[X])
         larray[X] = len(array[X])
         sarray[X] = sum(array[X])
-        #print(array[X])
+        
     for X in range(0,bssize):
         #Games are sampled, not moves. ACPL calculated on move-basis, though.
         #Games in bootstrap sample is equal to number of games in CR sample.
@@ -148,22 +131,21 @@ def bca(array):
         bootsample = 0.0
         deltalen = 0
         for Y in range(0,len(array)):
-            randnum = randrange_stripped(len(array))
+            randnum = randrange_stripped(len(array)) #runtime bottleneck
             bootsample += sarray[randnum]
             deltalen += larray[randnum]
         deltas[X] = bootsample / deltalen
-    deltas = sorted(deltas)
 
-    #https://www.tau.ac.il/~saharon/Boot/10.1.1.133.8405.pdf for theory
+    deltas = sorted(deltas) #sorting makes this a bootstrap distribution function
+    
     mean = sum(deltas)/len(deltas)
-    z0 = invcdf(Gcdf(deltas, mean))
-    a = skewness(sarray, larray) #use sampled distribution, not the bootstrap
+    z0 = invcdf(Gcdf(deltas, mean)) #bias correction parameter
+    a = skewness(sarray, larray) #acceleration parameter
     a1 = 0.025
     a2 = 0.975
     thetaa1 = invGcdf(deltas, cdf(z0 + (z0 + invcdf(a1))/(1-a*(z0+invcdf(a1)))))
     thetaa2 = invGcdf(deltas, cdf(z0 + (z0 + invcdf(a2))/(1-a*(z0+invcdf(a2)))))
 
-    #print(time.time()-stime)
     return [round(thetaa1,1), round(thetaa2,1)]
 
 
@@ -257,38 +239,29 @@ class PgnSpyResult():
         return -wilson_interval(self.t3_count, self.t3_total)[0]
 
 def t_output(fout, result):
-    #Commented some of the less important output to make it easier on the eyes
+    # commented lines are for CR on moves outside the unclear threshold. work in progress.
     if result.t1_total:
         fout.write('T1: {}\n'.format(generate_stats_string(result.t1_count, result.t1_total)))
     if result.t2_total:
         fout.write('T2: {}\n'.format(generate_stats_string(result.t2_count, result.t2_total)))
     if result.t3_total:
         fout.write('T3: {}\n'.format(generate_stats_string(result.t3_count, result.t3_total)))
-    if result.wt1_total:
-        fout.write('WT1: {}\n'.format(generate_stats_string(result.wt1_count, result.wt1_total)))
+    #if result.wt1_total:
+    #    fout.write('WT1: {}\n'.format(generate_stats_string(result.wt1_count, result.wt1_total)))
     #if result.wt2_total:
     #    fout.write('WT2: {}\n'.format(generate_stats_string(result.wt2_count, result.wt2_total)))
     #if result.wt3_total:
     #    fout.write('WT3: {}\n'.format(generate_stats_string(result.wt3_count, result.wt3_total)))
-    if result.bt1_total:
-        fout.write('BT1: {}\n'.format(generate_stats_string(result.bt1_count, result.bt1_total)))
+    #if result.bt1_total:
+    #    fout.write('BT1: {}\n'.format(generate_stats_string(result.bt1_count, result.bt1_total)))
     #if result.bt2_total:
     #    fout.write('BT2: {}\n'.format(generate_stats_string(result.bt2_count, result.bt2_total)))
     #if result.bt3_total:
     #    fout.write('BT3: {}\n'.format(generate_stats_string(result.bt3_count, result.bt3_total)))
     
     if result.acpl:
-        game_acpl = [] #temp variable to help with averaging ACPLs of games
-        for X in range(0,len(result.cp_loss_list_by_game)):
-            if len(result.cp_loss_list_by_game[X]):
-                game_acpl.append(sum(result.cp_loss_list_by_game[X])/len(result.cp_loss_list_by_game[X]))
-        #Print ACPL calculated from average CPLs of moves
+        # print ACPL line using BCa CI. numbers in parenthesis are number of moves and number of games, respectively
         fout.write(f'ACPL: {result.acpl:.1f} {str(bca(result.cp_loss_list_by_game))} ({result.sample_size}) ({len(result.cp_loss_list_by_game)})\n')
-        #Print ACPL calculated from average ACPLs of games, if possible
-        #if len(game_acpl):
-        #    fout.write(f'ACPL G: {sum(game_acpl)/len(game_acpl):.1f} ({len(game_acpl)}) {str(bootstrap_interval(game_acpl))}\n')
-        #Print the CP loss list array, for debugging purposes
-        #fout.write(f'{str(result.cp_loss_list_by_game)}\n')
     total = result.cp_loss_total
     if total > 0:
         for cp_loss_name in _cp_loss_names:
@@ -296,26 +269,24 @@ def t_output(fout, result):
             stats_str = generate_stats_string(loss_count, total)
             fout.write(f'  {cp_loss_name} CP loss: {stats_str}\n')
 
-#Character spam since I don't know any better ways to do it
-#I never use CSV exports, so this isn't priority for me to tidy up
 def t_output_csv(fout, result):
     #Commenting out lesser used stats to make it easier on the eyes
     if result.t1_total:
         fout.write(f'{result.t1_count}/{result.t1_total},{result.t1_count / result.t1_total:.1%},')
     else:
-        fout.write('x,x,')
+        fout.write(',,')
     if result.t2_total:
         fout.write(f'{result.t2_count}/{result.t2_total},{result.t2_count / result.t2_total:.1%},')
     else:
-        fout.write('x,x,')
+        fout.write(',,')
     if result.t3_total:
         fout.write(f'{result.t3_count}/{result.t3_total},{result.t3_count / result.t3_total:.1%},')
     else:
-        fout.write('x,x,')
-    if result.wt1_total:
-        fout.write(f'{result.wt1_count}/{result.wt1_total},{result.wt1_count / result.wt1_total:.1%},')
-    else:
-        fout.write('x,x,')
+        fout.write(',,')
+    #if result.wt1_total:
+    #    fout.write(f'{result.wt1_count}/{result.wt1_total},{result.wt1_count / result.wt1_total:.1%},')
+    #else:
+    #    fout.write(',,')
     #if result.wt2_total:
     #    fout.write(f'{result.wt2_count}/{result.wt2_total},{result.wt2_count / result.wt2_total:.1%},')
     #else:
@@ -324,10 +295,10 @@ def t_output_csv(fout, result):
     #    fout.write(f'{result.wt3_count}/{result.wt3_total},{result.wt3_count / result.wt3_total:.1%},')
     #else:
     #    fout.write('x,x,')
-    if result.bt1_total:
-        fout.write(f'{result.bt1_count}/{result.bt1_total},{result.bt1_count / result.bt1_total:.1%},')
-    else:
-        fout.write('x,x,')
+    #if result.bt1_total:
+    #    fout.write(f'{result.bt1_count}/{result.bt1_total},{result.bt1_count / result.bt1_total:.1%},')
+    #else:
+    #    fout.write('x,x,')
     #if result.bt2_total:
     #    fout.write(f'{result.bt2_count}/{result.bt2_total},{result.bt2_count / result.bt2_total:.1%},')
     #else:
@@ -340,16 +311,7 @@ def t_output_csv(fout, result):
         #Print ACPL calculated from average CPLs of moves
         fout.write(f'{result.acpl:.1f},{result.sample_size},{len(result.cp_loss_list_by_game)},{str(bca(result.cp_loss_list_by_game))},')
     else:
-        fout.write('x,x,x,x,x,')
-    #Print ACPL calculated from average ACPLs of games, if possible
-    #game_acpl = [] #temp variable to help with averaging ACPLs of games
-    #for X in range(0,len(result.cp_loss_list_by_game)):
-    #    if len(result.cp_loss_list_by_game[X]):
-    #        game_acpl.append(sum(result.cp_loss_list_by_game[X])/len(result.cp_loss_list_by_game[X]))
-    #if len(game_acpl):
-    #    fout.write(f'{sum(game_acpl)/len(game_acpl):.1f},{len(game_acpl)},{str(bootstrap_interval(game_acpl))},')
-    #else:
-    #    fout.write('x,x,x,x,')
+        fout.write(',,,,,')
 
     total = result.cp_loss_total
     if total > 0:
@@ -381,13 +343,12 @@ def a1(working_set, report_name):
     out_path = f'reports/report-a1--{datetime.now():%Y-%m-%d--%H-%M-%S}--{report_name}.txt'
     with open(out_path, 'w') as fout:
         fout.write('------ BY PLAYER ------\n\n')
-        #print("Started")
-        #stim = time.time()
         for player, result in sorted(by_player.items(), key=lambda i: i[1].t3_sort):
             fout.write(f'{player.username} ({result.min_rating} - {result.max_rating})\n')
             t_output(fout, result)
             fout.write(' '.join(result.game_list) + '\n')
             fout.write('\n')
+            
         #I've never looked at CR on a game-basis, and I don't think anyone ever should
         #fout.write('\n------ BY GAME ------\n\n')
         #for (player, gameid), result in sorted(by_game.items(), key=lambda i: i[1].t3_sort):
@@ -395,7 +356,6 @@ def a1(working_set, report_name):
         #    t_output(fout, result)
         #    fout.write(' '.join(result.game_list) + '\n')
         #    fout.write('\n')
-        #print(time.time()-stim)
     print(f'Wrote report on {included} games to "{out_path}"')
 
 def a1csv(working_set, report_name):
@@ -419,8 +379,8 @@ def a1csv(working_set, report_name):
     with open(out_path, 'w') as fout:
         cp_loss_name_string = ''
         for cp_loss_name in _cp_loss_names:
-            cp_loss_name_string += f'CPL{cp_loss_name},CPL{cp_loss_name}%,CPL{cp_loss_name} CI lower,CPL{cp_loss_name} CI upper,'
-        fout.write(f'Name,Rating range,T1:,T1%:,T2:,T2%:,T3:,T3%:,WT1:,WT1%,BT1:,BT1%:,ACPL:,Positions,Games,LCI,UCI,{cp_loss_name_string}Games\n')
+            cp_loss_name_string += f'CPL{cp_loss_name},CPL{cp_loss_name}%,CPL{cp_loss_name} CI,'
+        fout.write(f'Name,Rating range,T1:,T1%:,T2:,T2%:,T3:,T3%:,ACPL:,Positions,Games,LCI,UCI,{cp_loss_name_string}Games\n')
         for player, result in sorted(by_player.items(), key=lambda i: i[1].t3_sort):
             fout.write(f'{player.username},{result.min_rating} - {result.max_rating},')
             t_output_csv(fout, result)
@@ -448,8 +408,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
         if m.number <= p['book_depth']:
             continue
 		
-	#Start of major edits. Trying to make my dreams come true
-        #Tracks negative eval positions.
+        # tracks T% for negative eval positions. needs some work. maybe limited because CR stops evaluating past +/-5?
         if m.pv1_eval > p['undecided_pos_thresh'] and m.pv1_eval <= 99999:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -468,8 +427,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                                 r.bt3_count += 1
             continue
         
-	#Second stage of major edits
-        #Tracks positive eval positions (not as useful, probably)
+	# tracks T% for negative eval positions. needs some work. maybe limited because CR stops evaluating past +/-5?
         if m.pv1_eval < -p['undecided_pos_thresh'] and m.pv1_eval >= -99999:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -488,8 +446,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                                 r.wt3_count += 1
             continue
 
-	#Basically what it was originally
-        #Tracks undecided positions
+        # tracks undecided positions. the typical CR evaluation interval.
         if abs(m.pv1_eval) <= p['undecided_pos_thresh']:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -506,12 +463,12 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                             r.t3_total += 1
                             if m.played_rank and m.played_rank <= 3:
                                 r.t3_count += 1
-        #Should be foolproof to do it like this?
-        #Only go on to calculate ACPLs if undecided position
-        #So that old results still have the same ACPL calculations
+
+        # if the position wasn't undecided, don't proceed with CPL math
         else:
             continue
 
+        # store CPL distribution data to self
         initial_cpl = max(m.pv1_eval - m.played_eval, 0)
         r.cp_loss_total += 1
         for cp_name, cp_op in zip(_cp_loss_names, _cp_loss_ops):
@@ -527,7 +484,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
         r.sample_total_cpl += cpl
         r.cp_loss_list_by_move.append(cpl)
         r.cp_loss_list_by_game.append(cpl)
-        #Have so many questions about this part
+
         if cpl > 0:
             r.gt0 += 1
         if cpl > 10:

--- a/analyze.py
+++ b/analyze.py
@@ -73,21 +73,21 @@ class PgnSpyResult():
         self.sample_total_cpl += other.sample_total_cpl
         self.gt0 += other.gt0
         self.gt10 += other.gt10
+        
         self.t1_total += other.t1_total
         self.t1_count += other.t1_count
         self.t2_total += other.t2_total
         self.t2_count += other.t2_count
         self.t3_total += other.t3_total
         self.t3_count += other.t3_count
-    	####
+        
         self.wt1_total += other.wt1_total
         self.wt1_count += other.wt1_count
         self.wt2_total += other.wt2_total
         self.wt2_count += other.wt2_count
         self.wt3_total += other.wt3_total
         self.wt3_count += other.wt3_count
-        ####
-        ####
+
         self.bt1_total += other.bt1_total
         self.bt1_count += other.bt1_count
         self.bt2_total += other.bt2_total
@@ -147,20 +147,42 @@ def t_output(fout, result):
             stats_str = generate_stats_string(loss_count, total)
             fout.write(f'  {cp_loss_name} CP loss: {stats_str}\n')
 
+#Character spam since I don't know any better ways to do it
 def t_output_csv(fout, result):
     if result.t1_total:
         fout.write(f'{result.t1_count}/{result.t1_total},{result.t1_count / result.t1_total:.1%},')
-        fout.write(f'{result.wt1_count}/{result.wt1_total},{result.wt1_count / result.wt1_total:.1%},')
     else:
         fout.write('x,x,')
     if result.t2_total:
         fout.write(f'{result.t2_count}/{result.t2_total},{result.t2_count / result.t2_total:.1%},')
-        fout.write(f'{result.wt2_count}/{result.wt2_total},{result.wt2_count / result.wt2_total:.1%},')
     else:
         fout.write('x,x,')
     if result.t3_total:
         fout.write(f'{result.t3_count}/{result.t3_total},{result.t3_count / result.t3_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.wt1_total:
+        fout.write(f'{result.wt1_count}/{result.wt1_total},{result.wt1_count / result.wt1_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.wt2_total:
+        fout.write(f'{result.wt2_count}/{result.wt2_total},{result.wt2_count / result.wt2_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.wt3_total:
         fout.write(f'{result.wt3_count}/{result.wt3_total},{result.wt3_count / result.wt3_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.bt1_total:
+        fout.write(f'{result.bt1_count}/{result.bt1_total},{result.bt1_count / result.bt1_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.bt2_total:
+        fout.write(f'{result.bt2_count}/{result.bt2_total},{result.bt2_count / result.bt2_total:.1%},')
+    else:
+        fout.write('x,x,')
+    if result.bt3_total:
+        fout.write(f'{result.bt3_count}/{result.bt3_total},{result.bt3_count / result.bt3_total:.1%},')
     else:
         fout.write('x,x,')
     if result.acpl:
@@ -261,7 +283,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
         if m.number <= p['book_depth']:
             continue
 		
-	#Skip positions if they're better (assuming people don't cheat when better)
+	#Start of major edits. Trying to make my dreams come true
         if m.pv1_eval > p['undecided_pos_thresh'] and m.pv1_eval <= 99999:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -280,7 +302,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                                 r.bt3_count += 1
             continue
         
-	#Make a separate disply for losing positions
+	#Second stage of major edits
         if m.pv1_eval < -p['undecided_pos_thresh'] and m.pv1_eval >= -99999:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -298,9 +320,8 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                             if m.played_rank and m.played_rank <= 3:
                                 r.wt3_count += 1
             continue
-		
 
-###############
+	#Basically what it was originally
         if abs(m.pv1_eval) <= p['undecided_pos_thresh']:
             if m.pv2_eval is not None and m.pv1_eval <= m.pv2_eval + p['forced_move_thresh'] and m.pv1_eval <= m.pv2_eval + p['unclear_pos_thresh']:
                 if m.pv2_eval < m.pv1_eval:
@@ -317,11 +338,9 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
                             r.t3_total += 1
                             if m.played_rank and m.played_rank <= 3:
                                 r.t3_count += 1
-        else:#Don't do the rest if this condition isn't the one that's met
+        else:#Should be foolproof to do it like this?
             continue
 
-
-################
         initial_cpl = max(m.pv1_eval - m.played_eval, 0)
         r.cp_loss_total += 1
         for cp_name, cp_op in zip(_cp_loss_names, _cp_loss_ops):
@@ -335,6 +354,7 @@ def a1_game(p, by_player, by_game, game_obj, pgn, color, player):
 
         r.sample_size += 1
         r.sample_total_cpl += cpl
+        #Have so many questions about this part
         if cpl > 0:
             r.gt0 += 1
         if cpl > 10:

--- a/analyze.py
+++ b/analyze.py
@@ -157,7 +157,7 @@ def bca(array):
     #https://www.tau.ac.il/~saharon/Boot/10.1.1.133.8405.pdf for theory
     mean = sum(deltas)/len(deltas)
     z0 = invcdf(Gcdf(deltas, mean))
-    a = skewness(deltas, [1]*len(deltas))
+    a = skewness(sarray, larray) #use sampled distribution, not the bootstrap
     a1 = 0.025
     a2 = 0.975
     thetaa1 = invGcdf(deltas, cdf(z0 + (z0 + invcdf(a1))/(1-a*(z0+invcdf(a1)))))

--- a/analyze.py
+++ b/analyze.py
@@ -112,7 +112,7 @@ def invcdf(phi): #bisection method
 # https://www.tau.ac.il/~saharon/Boot/10.1.1.133.8405.pdf for theory
 def bca(array):
     if len(array) < 2:
-        return ['-', '-']
+        return ['-','-']
     bssize = 20000-1 #19999 samples reproducibly gives upper and lower CIs +/-0.2
     deltas = [0]*bssize #bootstrap samples. deltas was the legacy name used for a reverse percentile method (not being used)
     sarray = [0]*len(array) #sum of CPLs in individual games
@@ -272,41 +272,41 @@ def t_output(fout, result):
 def t_output_csv(fout, result):
     #Commenting out lesser used stats to make it easier on the eyes
     if result.t1_total:
-        fout.write(f'{result.t1_count}/{result.t1_total},{result.t1_count / result.t1_total:.1%},')
+        fout.write(f'{generate_stats_string_csv(result.t1_count, result.t1_total)},')
     else:
-        fout.write(',,')
+        fout.write(',,,')
     if result.t2_total:
-        fout.write(f'{result.t2_count}/{result.t2_total},{result.t2_count / result.t2_total:.1%},')
+        fout.write(f'{generate_stats_string_csv(result.t2_count, result.t2_total)},')
     else:
-        fout.write(',,')
+        fout.write(',,,')
     if result.t3_total:
-        fout.write(f'{result.t3_count}/{result.t3_total},{result.t3_count / result.t3_total:.1%},')
+        fout.write(f'{generate_stats_string_csv(result.t3_count, result.t3_total)},')
     else:
-        fout.write(',,')
+        fout.write(',,,')
     #if result.wt1_total:
-    #    fout.write(f'{result.wt1_count}/{result.wt1_total},{result.wt1_count / result.wt1_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.wt1_count, result.wt1_total)},')
     #else:
-    #    fout.write(',,')
+    #    fout.write(',,,')
     #if result.wt2_total:
-    #    fout.write(f'{result.wt2_count}/{result.wt2_total},{result.wt2_count / result.wt2_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.wt2_count, result.wt2_total)},')
     #else:
-    #    fout.write('x,x,')
+    #    fout.write(',,,')
     #if result.wt3_total:
-    #    fout.write(f'{result.wt3_count}/{result.wt3_total},{result.wt3_count / result.wt3_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.wt3_count, result.wt3_total)},')
     #else:
-    #    fout.write('x,x,')
+    #    fout.write(',,,')
     #if result.bt1_total:
-    #    fout.write(f'{result.bt1_count}/{result.bt1_total},{result.bt1_count / result.bt1_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.bt1_count, result.bt1_total)},')
     #else:
-    #    fout.write('x,x,')
+    #    fout.write(',,,')
     #if result.bt2_total:
-    #    fout.write(f'{result.bt2_count}/{result.bt2_total},{result.bt2_count / result.bt2_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.bt2_count, result.bt2_total)},')
     #else:
-    #    fout.write('x,x,')
+    #    fout.write(',,,')
     #if result.bt3_total:
-    #    fout.write(f'{result.bt3_count}/{result.bt3_total},{result.bt3_count / result.bt3_total:.1%},')
+    #    fout.write(f'{generate_stats_string_csv(result.bt3_count, result.bt3_total)},')
     #else:
-    #    fout.write('x,x,')
+    #    fout.write(',,,')
     if result.acpl:
         #Print ACPL calculated from average CPLs of moves
         fout.write(f'{result.acpl:.1f},{result.sample_size},{len(result.cp_loss_list_by_game)},{str(bca(result.cp_loss_list_by_game))},')
@@ -321,7 +321,7 @@ def t_output_csv(fout, result):
             fout.write(f'{stats_str},')
     else:
         for cp_loss_name in _cp_loss_names:
-            fout.write(f',,,,')
+            fout.write(',,,')
 
 def a1(working_set, report_name):
     p = load_a1_params()
@@ -347,7 +347,7 @@ def a1(working_set, report_name):
             fout.write(f'{player.username} ({result.min_rating} - {result.max_rating})\n')
             t_output(fout, result)
             fout.write(' '.join(result.game_list) + '\n')
-            fout.write('\n')
+            fout.write(str(len(result.game_list)) + ' games \n\n')
             
         #I've never looked at CR on a game-basis, and I don't think anyone ever should
         #fout.write('\n------ BY GAME ------\n\n')
@@ -380,11 +380,11 @@ def a1csv(working_set, report_name):
         cp_loss_name_string = ''
         for cp_loss_name in _cp_loss_names:
             cp_loss_name_string += f'CPL{cp_loss_name},CPL{cp_loss_name}%,CPL{cp_loss_name} CI,'
-        fout.write(f'Name,Rating range,T1:,T1%:,T2:,T2%:,T3:,T3%:,ACPL:,Positions,Games,LCI,UCI,{cp_loss_name_string}Games\n')
+        fout.write(f'Name,Rating min,Rating max,T1:,T1%:,T1 CI,T2:,T2%:,T2 CI,T3:,T3%:,T3 CI,ACPL,Positions,# Games,ACPL Lower CI,ACPL Upper CI,{cp_loss_name_string}# Games,Games\n')
         for player, result in sorted(by_player.items(), key=lambda i: i[1].t3_sort):
-            fout.write(f'{player.username},{result.min_rating} - {result.max_rating},')
+            fout.write(f'{player.username},{result.min_rating},{result.max_rating},')
             t_output_csv(fout, result)
-            fout.write(' '.join(result.game_list) + '\n')
+            fout.write(str(len(result.game_list)) + ',' + ' '.join(result.game_list) + '\n')
 
     print(f'Wrote report on {included} games to "{out_path}"')
 


### PR DESCRIPTION
Addresses https://github.com/cyanfish/ChessReanalysis/issues/4.

This version uses 95% bias-corrected and accelerated bootstrap confidence intervals for ACPL. Previous work showed that CPL distributions are more exponential than Gaussian, so normal confidence intervals are less accurate. At 19999 replicates, the 95% confidence interval bounds are good to +/-0.2 over 100 simulations for low sample sizes (10 games), and good to +/-0.1 for large sample sizes (90 games).

There is a bit of runtime lengthening due to the number of simulations needed. This is on the order of seconds for typical CR usage, and even for larger applications it's still negligible compared to the total preprocess+analysis runtime. The bottleneck is a large amount of random number generation; NumPy would cut this down significantly, but would also require an extra installation.

This version also removes BY GAME output, since that is never used and should never be used for hunter work. There are other formatting changes as needed. Large blocks of new code are commented out since they are, eventually, to be used for T% analysis on positions outside of the undecided threshold.